### PR TITLE
fix: Default cache behaviour variable value

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,19 +30,24 @@ No modules.
 | <a name="input_cache_policy_id"></a> [cache\_policy\_id](#input\_cache\_policy\_id) | AWS managed cache policy id | `string` | `""` | no |
 | <a name="input_cached_methods"></a> [cached\_methods](#input\_cached\_methods) | Cached methods | `list(any)` | <pre>[<br>  "GET",<br>  "HEAD"<br>]</pre> | no |
 | <a name="input_comment"></a> [comment](#input\_comment) | n/a | `string` | `" "` | no |
+| <a name="input_compress"></a> [compress](#input\_compress) | Compress file | `bool` | `false` | no |
 | <a name="input_custom_error_response"></a> [custom\_error\_response](#input\_custom\_error\_response) | Custom error response | `list(any)` | `[]` | no |
+| <a name="input_default_cache_behaviour_target_origin_id"></a> [default\_cache\_behaviour\_target\_origin\_id](#input\_default\_cache\_behaviour\_target\_origin\_id) | Target origin ID for default cache behaviour | `string` | n/a | yes |
+| <a name="input_default_cache_forwarded_values"></a> [default\_cache\_forwarded\_values](#input\_default\_cache\_forwarded\_values) | forwarded values for default cache behavior | `any` | `{}` | no |
 | <a name="input_default_root_object"></a> [default\_root\_object](#input\_default\_root\_object) | Default root object | `string` | `"index.html"` | no |
 | <a name="input_domain_aliases"></a> [domain\_aliases](#input\_domain\_aliases) | domain aliases | `list(string)` | `null` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Cloudfront state | `bool` | `true` | no |
 | <a name="input_function_association"></a> [function\_association](#input\_function\_association) | Function association | `list(any)` | `[]` | no |
 | <a name="input_http_version"></a> [http\_version](#input\_http\_version) | HTTP version to be allowed | `string` | `"http2"` | no |
-| <a name="input_ipv6"></a> [ipv6](#input\_ipv6) | ipv6 status | `bool` | `false` | no |
+| <a name="input_is_ipv6_enabled"></a> [is\_ipv6\_enabled](#input\_is\_ipv6\_enabled) | ipv6 status | `bool` | `false` | no |
 | <a name="input_lambda_function_association"></a> [lambda\_function\_association](#input\_lambda\_function\_association) | Lambda edge association | `list(any)` | `[]` | no |
 | <a name="input_logging_config"></a> [logging\_config](#input\_logging\_config) | Cloudfront logging config | `map(any)` | `{}` | no |
+| <a name="input_ordered_cache_behavior"></a> [ordered\_cache\_behavior](#input\_ordered\_cache\_behavior) | List of ordered cache behaviour | `any` | `[]` | no |
 | <a name="input_origin"></a> [origin](#input\_origin) | Origin configuration | `any` | n/a | yes |
 | <a name="input_origin_request_policy_id"></a> [origin\_request\_policy\_id](#input\_origin\_request\_policy\_id) | Unique identifier of the origin request policy that is attached to the behavior | `string` | `""` | no |
 | <a name="input_route53_zone_id"></a> [route53\_zone\_id](#input\_route53\_zone\_id) | Route53 zone id | `string` | `""` | no |
 | <a name="input_ttl_values"></a> [ttl\_values](#input\_ttl\_values) | map of ttl variables | `map(any)` | `{}` | no |
+| <a name="input_viewer_protocol_policy"></a> [viewer\_protocol\_policy](#input\_viewer\_protocol\_policy) | the protocol that users can use to access the files in the origin, valid values are allow-all, https-only, or redirect-to-https. | `string` | `"redirect-to-https"` | no |
 | <a name="input_web_acl_id"></a> [web\_acl\_id](#input\_web\_acl\_id) | WAF web ACL id | `string` | `""` | no |
 
 ## Outputs

--- a/variables.tf
+++ b/variables.tf
@@ -136,5 +136,5 @@ variable "ordered_cache_behavior" {
 variable "default_cache_forwarded_values" {
   description = "forwarded values for default cache behavior"
   type        = any
-  default     = []
+  default     = {}
 }


### PR DESCRIPTION
Changed `default_cache_forwarded_values` from [] to {}